### PR TITLE
don't send User data to Sentry by default

### DIFF
--- a/services/sentry.py-tpl
+++ b/services/sentry.py-tpl
@@ -28,5 +28,5 @@ def initialise_sentry():
         dsn,
         environment=environment,
         integrations=[DjangoIntegration()],
-        send_default_pii=True,
+        send_default_pii=False,
     )


### PR DESCRIPTION
Copying #opensafely-core/interactive.opensafely.org#276 to the template.